### PR TITLE
Expose ToQueryable in order to use along with OData (ApplyTo)

### DIFF
--- a/samples/EntityFrameworkCore.WebAPI/EntityFrameworkCore.WebAPI.csproj
+++ b/samples/EntityFrameworkCore.WebAPI/EntityFrameworkCore.WebAPI.csproj
@@ -20,14 +20,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.3" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.9" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.10" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCore.AutoHistory/EntityFrameworkCore.AutoHistory.csproj
+++ b/src/EntityFrameworkCore.AutoHistory/EntityFrameworkCore.AutoHistory.csproj
@@ -16,13 +16,13 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>EntityFrameworkCore;Entity Framework Core;entity-framework-core;EFCore;EF;Data;O/RM;AutoHistory;Auto History;auto-history</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>6.0.6</Version>
+    <Version>6.0.7</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/EntityFrameworkCore.QueryBuilder.Abstractions/EntityFrameworkCore.QueryBuilder.Abstractions.csproj
+++ b/src/EntityFrameworkCore.QueryBuilder.Abstractions/EntityFrameworkCore.QueryBuilder.Abstractions.csproj
@@ -17,12 +17,12 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>EntityFrameworkCore;Entity Framework Core;entity-framework-core;EFCore;EF;Data;O/RM;QueryBuilder;Query Builder;query-builder;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>6.0.6</Version>
+    <Version>6.0.7</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/EntityFrameworkCore.QueryBuilder/EntityFrameworkCore.QueryBuilder.csproj
+++ b/src/EntityFrameworkCore.QueryBuilder/EntityFrameworkCore.QueryBuilder.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>EntityFrameworkCore;Entity Framework Core;entity-framework-core;EFCore;EF;Data;O/RM;QueryBuilder;Query Builder;query-builder</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>6.0.6</Version>
+    <Version>6.0.7</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/EntityFrameworkCore.Repository.Abstractions/EntityFrameworkCore.Repository.Abstractions.csproj
+++ b/src/EntityFrameworkCore.Repository.Abstractions/EntityFrameworkCore.Repository.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>EntityFrameworkCore;Entity Framework Core;entity-framework-core;EFCore;EF;Data;O/RM;Repository;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>6.0.6</Version>
+    <Version>6.0.7</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/EntityFrameworkCore.Repository.Abstractions/Interfaces/ISyncRepository.cs
+++ b/src/EntityFrameworkCore.Repository.Abstractions/Interfaces/ISyncRepository.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 
 namespace EntityFrameworkCore.Repository.Interfaces
@@ -43,5 +44,7 @@ namespace EntityFrameworkCore.Repository.Interfaces
         void ChangeState(T entity, EntityState state);
         void TrackGraph(T rootEntity, Action<EntityEntryGraphNode> callback);
         void TrackGraph<TState>(T rootEntity, TState state, Func<EntityEntryGraphNode<TState>, bool> callback);
+        IQueryable<T> ToQueryable(IQuery<T> query);
+        IQueryable<TResult> ToQueryable<TResult>(IQuery<T, TResult> query);
     }
 }

--- a/src/EntityFrameworkCore.Repository/EntityFrameworkCore.Repository.csproj
+++ b/src/EntityFrameworkCore.Repository/EntityFrameworkCore.Repository.csproj
@@ -16,12 +16,12 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>EntityFrameworkCore;Entity Framework Core;entity-framework-core;EFCore;EF;Data;O/RM;Repository</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>6.0.6</Version>
+    <Version>6.0.7</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="6.13.16" />
+    <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="6.15.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCore.Repository/Repository.cs
+++ b/src/EntityFrameworkCore.Repository/Repository.cs
@@ -781,9 +781,7 @@ namespace EntityFrameworkCore.Repository
 
         #endregion IAsyncRepository<T> Members
 
-        #region Private Methods
-
-        private IQueryable<T> ToQueryable(IQuery<T> query)
+        public IQueryable<T> ToQueryable(IQuery<T> query)
         {
             IMultipleResultQuery<T> multipleResultQuery = null;
 
@@ -844,7 +842,7 @@ namespace EntityFrameworkCore.Repository
             return queryable;
         }
 
-        private IQueryable<TResult> ToQueryable<TResult>(IQuery<T, TResult> query)
+        public IQueryable<TResult> ToQueryable<TResult>(IQuery<T, TResult> query)
         {
             IMultipleResultQuery<T, TResult> multipleResultQuery = null;
 
@@ -899,6 +897,8 @@ namespace EntityFrameworkCore.Repository
 
             return queryable.Select(query.Selector);
         }
+
+        #region Private Methods
 
         private IQueryable<T> GetQueryable(QueryTrackingBehavior? queryTrackingBehavior = null, bool? ignoreQueryFilters = null)
         {

--- a/src/EntityFrameworkCore.UnitOfWork.Abstractions/EntityFrameworkCore.UnitOfWork.Abstractions.csproj
+++ b/src/EntityFrameworkCore.UnitOfWork.Abstractions/EntityFrameworkCore.UnitOfWork.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>EntityFrameworkCore;Entity Framework Core;entity-framework-core;EFCore;EF;Data;O/RM;UnitOfWork;Unit Of Work;unit-of-work;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>6.0.6</Version>
+    <Version>6.0.7</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/EntityFrameworkCore.UnitOfWork/EntityFrameworkCore.UnitOfWork.csproj
+++ b/src/EntityFrameworkCore.UnitOfWork/EntityFrameworkCore.UnitOfWork.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>EntityFrameworkCore;Entity Framework Core;entity-framework-core;EFCore;EF;Data;O/RM;UnitOfWork;Unit Of Work;unit-of-work</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>6.0.6</Version>
+    <Version>6.0.7</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/tests/EntityFrameworkCore.Tests/EntityFrameworkCore.Tests.csproj
+++ b/tests/EntityFrameworkCore.Tests/EntityFrameworkCore.Tests.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Hi I made this PR because I want to combine the query it is built with MultipleResultQuery with another IQueryable provider like OData, the repository was not capable to expose a IQueryable, so the query can't be extended.

This is what I can do now:

```
public async Task<IActionResult> SearchDto(ODataQueryOptions<Entity> oquery)
        {
            var repo = _unitOfWork.Repository<Entity>();
            var query = repo.MultipleResultQuery()
                                .Include(source => source.Include(doc => doc.AnotherEntity))
                                .OrderByDescending(s => s.CreationTime);

            var queryable = repo.ToQueryable(query);  // Obtain an IQueryable

            var entities = oquery.ApplyTo(queryable);          // Apply OData filters to the IQueryable

            return Ok(entities);
        }
```

I also bump nuget version to 6.0.7
and update few dependencies to the latest compatible version.