### PR TITLE
Add GetState and fix IsRelational bug

### DIFF
--- a/src/EntityFrameworkCore.Repository.Abstractions/Interfaces/ISyncRepository.cs
+++ b/src/EntityFrameworkCore.Repository.Abstractions/Interfaces/ISyncRepository.cs
@@ -9,10 +9,10 @@ using System.Linq.Expressions;
 
 namespace EntityFrameworkCore.Repository.Interfaces
 {
-    public interface ISyncRepository : IRepository, IDisposable
+    public interface ISyncRepository : IRepository
     { }
 
-    public interface ISyncRepository<T> : ISyncRepository, IQueryFactory<T>, IDisposable where T : class
+    public interface ISyncRepository<T> : ISyncRepository, IQueryFactory<T> where T : class
     {
         IList<T> Search(IQuery<T> query);
         IList<TResult> Search<TResult>(IQuery<T, TResult> query);
@@ -43,6 +43,7 @@ namespace EntityFrameworkCore.Repository.Interfaces
         IList<T> FromSql(string sql, params object[] parameters);
         void ChangeTable(string table);
         void ChangeState(T entity, EntityState state);
+        EntityState GetState(T entity);
         void Reload(T entity);
         void TrackGraph(T rootEntity, Action<EntityEntryGraphNode> callback);
         void TrackGraph<TState>(T rootEntity, TState state, Func<EntityEntryGraphNode<TState>, bool> callback);

--- a/src/EntityFrameworkCore.Repository/Repository.cs
+++ b/src/EntityFrameworkCore.Repository/Repository.cs
@@ -482,6 +482,15 @@ namespace EntityFrameworkCore.Repository
 
             DbContext.Entry(entity).State = state;
         }
+        public EntityState GetState(T entity)
+        {
+            if (entity == null)
+            {
+                throw new ArgumentNullException(nameof(entity), $"{nameof(entity)} cannot be null.");
+            }
+
+            return DbContext.Entry(entity).State;
+        }
 
         public virtual void Reload(T entity)
         {


### PR DESCRIPTION
I like this project, but I was missing a feature to retrieve the state of an entity, and I took the opportunity to fix a bug that I noticed when using this package in another project. The bug was triggered when calling the IsRelational() method of the Entity Framework when disposing of the object, but only when there had been no database connection established.

Do you believe a new version of the NuGet package can be pushed soon? I'm hoping not to carry all this code in my project.

Thank you, and great job!